### PR TITLE
Use gradle task for getting subprojects instead of reading settings files

### DIFF
--- a/build.go
+++ b/build.go
@@ -12,7 +12,7 @@ import (
 )
 
 func build() {
-	gradlew(config.Aliucord, ":Aliucord:compileDebugJavaWithJavac")
+	gradlew(os.Stdout, config.Aliucord, ":Aliucord:compileDebugJavaWithJavac")
 
 	javacBuild, err := filepath.Abs(config.Aliucord + "/Aliucord/build/intermediates/javac/debug")
 	if err != nil {
@@ -38,7 +38,7 @@ func build() {
 	zipw.Close()
 	f.Close()
 
-	execCmd(config.Outputs, "d8", javacBuild+"/aliucord.zip")
+	execCmd(os.Stdout, config.Outputs, "d8", javacBuild+"/aliucord.zip")
 
 	out := "Aliucord.dex"
 	if *outName != "" {
@@ -61,7 +61,7 @@ func buildPlugin(pluginName string) {
 		log.Fatal(err)
 	}
 
-	gradlew(config.Plugins, pluginName+":compileDebugJavaWithJavac")
+	gradlew(os.Stdout, config.Plugins, pluginName+":compileDebugJavaWithJavac")
 
 	javacBuild := plugin + "/build/intermediates/javac/debug"
 	f, _ := os.Create(javacBuild + "/classes.zip")
@@ -93,7 +93,7 @@ func buildPlugin(pluginName string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	execCmd(outputsPlugins, "d8", javacBuild+"/classes.zip")
+	execCmd(os.Stdout, outputsPlugins, "d8", javacBuild+"/classes.zip")
 
 	out := pluginName + ".zip"
 	if *outName != "" {
@@ -109,8 +109,8 @@ func buildPlugin(pluginName string) {
 		if err == nil && len(files) > 0 {
 			tmpApk := outputsPlugins + "/" + pluginName + "-tmp.apk"
 
-			execCmd(outputsPlugins, "aapt2", "compile", "--dir", src+"/res", "-o", "tmpres.zip")
-			execCmd(outputsPlugins, "aapt2", "link", "-I", config.AndroidSDK+"/platforms/android-"+config.AndroidSDKVersion+"/android.jar",
+			execCmd(os.Stdout, outputsPlugins, "aapt2", "compile", "--dir", src+"/res", "-o", "tmpres.zip")
+			execCmd(os.Stdout, outputsPlugins, "aapt2", "link", "-I", config.AndroidSDK+"/platforms/android-"+config.AndroidSDKVersion+"/android.jar",
 				"-R", "tmpres.zip", "--manifest", src+"/AndroidManifest.xml", "-o", tmpApk)
 			os.Remove(outputsPlugins + "/tmpres.zip")
 

--- a/main.go
+++ b/main.go
@@ -63,9 +63,11 @@ func main() {
 	} else if *plugin == "*" {
 		regex := regexp.MustCompile(`':(\w+)'`)
 		buffer := bytes.NewBufferString("")
+
 		gradlew(buffer, config.Plugins, "projects")
 
 		plugins := regex.FindAllStringSubmatch(buffer.String(), -1)
+
 		for i, plugin := range plugins {
 			pluginName := plugin[1] //Match the first group, since at index 0 we have the full string
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
@@ -59,8 +61,15 @@ func main() {
 	if *plugin == "" {
 		build()
 	} else if *plugin == "*" {
-		b, err = ioutil.ReadFile(config.Plugins + "/settings.gradle")
+		b, err = os.ReadFile(config.Plugins + "/settings.gradle.kts")
+
+		if err != nil {
+			b, _ = os.ReadFile(config.Plugins + "/settings.gradle")
+		}
+
 		file := strings.Split(string(b), "\n")
+
+		regex := regexp.MustCompile("include[\\s(][\"']:(\\w+)[\"']\\)?")
 
 		for i, ln := range file {
 			if len(strings.TrimSpace(ln)) == 0 {
@@ -75,7 +84,7 @@ func main() {
 				fmt.Print("\n")
 			}
 
-			pluginName := strings.TrimSpace(strings.Replace(strings.ReplaceAll(strings.ReplaceAll(ln, `"`, ""), "'", ""), "include :", "", 1))
+			pluginName := regex.FindStringSubmatch(ln)[1]
 			fmt.Printf(info+"\n", "Building plugin: "+pluginName)
 			buildPlugin(pluginName)
 		}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -61,30 +61,23 @@ func main() {
 	if *plugin == "" {
 		build()
 	} else if *plugin == "*" {
-		b, err = os.ReadFile(config.Plugins + "/settings.gradle.kts")
+		regex := regexp.MustCompile(`':(\w+)'`)
+		buffer := bytes.NewBufferString("")
+		gradlew(buffer, config.Plugins, "projects")
 
-		if err != nil {
-			b, _ = os.ReadFile(config.Plugins + "/settings.gradle")
-		}
+		plugins := regex.FindAllStringSubmatch(buffer.String(), -1)
 
-		file := strings.Split(string(b), "\n")
+		for i, plugin := range plugins {
+			pluginName := plugin[1] //Match the first group, since at index 0 we have the full string
 
-		regex := regexp.MustCompile("include[\\s(][\"']:(\\w+)[\"']\\)?")
-
-		for i, ln := range file {
-			if len(strings.TrimSpace(ln)) == 0 {
+			if pluginName == "Aliucord" || pluginName == "DiscordStubs" {
 				continue
-			}
-
-			if strings.Contains(ln, "rootProject.name") {
-				break
 			}
 
 			if i > 0 {
 				fmt.Print("\n")
 			}
 
-			pluginName := regex.FindStringSubmatch(ln)[1]
 			fmt.Printf(info+"\n", "Building plugin: "+pluginName)
 			buildPlugin(pluginName)
 		}

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/zip"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -9,19 +10,19 @@ import (
 	"strings"
 )
 
-func gradlew(dir string, args ...string) {
+func gradlew(stdout io.Writer, dir string, args ...string) {
 	if runtime.GOOS == "windows" {
-		execCmd(dir, "cmd", "/k", "gradlew.bat "+strings.Join(args, " ")+" && exit")
+		execCmd(stdout, dir, "cmd", "/k", "gradlew.bat "+strings.Join(args, " ")+" && exit")
 	} else {
-		execCmd(dir, "./gradlew", args...)
+		execCmd(stdout, dir, "./gradlew", args...)
 	}
 }
 
-func execCmd(dir, c string, args ...string) {
+func execCmd(stdout io.Writer, dir string, c string, args ...string) {
 	cmd := exec.Command(c, args...)
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = stdout
 	err := cmd.Run()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
# Info
Instead of reading `settings.gradle` or `settings.gradle.kts` files, we can use `gradlew projects` command to get all subprojects in the current project.

# Additional information
With this change, we can place plugins wherever we want in the `settings.gradle`/`settings.gradle.kts`. Before, we could only put them at the top of the settings file, before `rootProject.name = "..."`. This also invalidates the previous PR 😂 

# Important Changes
`gradlew()` and `execCmd()` functions now require `io.Writer` parameter for stdout